### PR TITLE
add missing terraform-init-flags to the terraform init command

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -84,7 +84,7 @@ runs:
       env:
         TF_WORKSPACE: ${{ inputs.terraform-workspace }}
       run: |
-        terraform init
+        terraform init ${{ inputs.terraform-init-flags }}
         terraform apply -input=false -no-color -auto-approve
       continue-on-error: true
 


### PR DESCRIPTION
the variable existed, but wasn't included on the `terraform init` line