### PR TITLE
Major refactor and new multi-cloud support

### DIFF
--- a/.github/workflows/test-action.yaml
+++ b/.github/workflows/test-action.yaml
@@ -16,7 +16,7 @@ permissions:
   contents: read  # This is required for actions/checkout
 
 jobs:
-  test-action:
+  test-aws:
     runs-on: ubuntu-latest
     steps:
 
@@ -41,6 +41,15 @@ jobs:
         run: |
           terraform destroy -auto-approve
 
+      
+
+  test-azure:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: 'Az CLI login'
         uses: azure/login@v2
         with:
@@ -59,6 +68,12 @@ jobs:
         run: |
           terraform destroy -auto-approve
 
+  # test-gcp:
+  #   runs-on: ubuntu-latest
+  #   steps:
+
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
       # - id: 'auth'
       #   name: 'Authenticate to GCP'
       #   uses: 'google-github-actions/auth@v0.3.1'

--- a/.github/workflows/test-action.yaml
+++ b/.github/workflows/test-action.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v3
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: "${{ env.AWS_ROLE }}"
           role-session-name: test-action-session

--- a/.github/workflows/test-action.yaml
+++ b/.github/workflows/test-action.yaml
@@ -41,10 +41,10 @@ jobs:
           terraform destroy -auto-approve
 
       - name: 'Az CLI login'
-        uses: azure/login@v1
+        uses: azure/login@v2
         with:
           client-id: ${{ env.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          tenant-id: ${{ env.AZURE_TENANT_ID }}
           subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
 
       - name: Test actions with an Azure backend

--- a/.github/workflows/test-action.yaml
+++ b/.github/workflows/test-action.yaml
@@ -6,9 +6,9 @@ on:
 env:
   AWS_ROLE: "arn:aws:iam::241033177617:role/allow-test-repo"
   AWS_REGION: "us-east-1"
-  AZURE_CLIENT_ID: "03b75287-e30e-4ac5-813b-ca074c26a325"
-  AZURE_SUBSCRIPTION_ID: "a267dbd7-a0ac-4f3e-a310-6bb813ff3078"
-  AZURE_TENANT_ID: "68f381e3-46da-47b9-ba57-6f322b8f0da1"
+  ARM_CLIENT_ID: "03b75287-e30e-4ac5-813b-ca074c26a325"
+  ARM_SUBSCRIPTION_ID: "a267dbd7-a0ac-4f3e-a310-6bb813ff3078"
+  ARM_TENANT_ID: "68f381e3-46da-47b9-ba57-6f322b8f0da1"
 
 permissions:
   id-token: write # This is required for requesting the JWT
@@ -43,9 +43,9 @@ jobs:
       - name: 'Az CLI login'
         uses: azure/login@v2
         with:
-          client-id: ${{ env.AZURE_CLIENT_ID }}
-          tenant-id: ${{ env.AZURE_TENANT_ID }}
-          subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
+          client-id: ${{ env.ARM_CLIENT_ID }}
+          tenant-id: ${{ env.ARM_TENANT_ID }}
+          subscription-id: ${{ env.ARM_SUBSCRIPTION_ID }}
 
       - name: Test actions with an Azure backend
         uses: ./ # Uses an action in the root directory

--- a/.github/workflows/test-action.yaml
+++ b/.github/workflows/test-action.yaml
@@ -2,10 +2,60 @@ name: Test This Composite Action
 on:
   workflow_dispatch:
 
+
+env:
+  AWS_ROLE: "arn:aws:iam::241033177617:role/allow-test-repo"
+  AWS_REGION: "us-east-1"
+  AZURE_CLIENT_ID: 
+  AZURE_SUBSCRIPTION_ID:
+  AZURE_TENANT_ID: 
+
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read  # This is required for actions/checkout
+
 jobs:
-  test-case:
+  test-action:
     runs-on: ubuntu-latest
     steps:
-      - uses: tamu-edu/it-ae-actions-pullrequest-tfapply@test
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v3
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          role-to-assume: "${{ env.AWS_ROLE }}"
+          role-session-name: test-action-session
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Test actions with an AWS backend
+        uses: ./ # Uses an action in the root directory
+        with:
+          working-directory: test/test-aws
+          no-pr: true
+
+      - name: Cleanup AWS test
+        working-directory: test/test-aws
+        run: |
+          terraform destroy -auto-approve
+
+      # - name: 'Az CLI login'
+      #   uses: azure/login@v1
+      #   with:
+      #     client-id: ${{ env.AZURE_CLIENT_ID }}
+      #     tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+      #     subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
+
+      # - id: 'auth'
+      #   name: 'Authenticate to GCP'
+      #   uses: 'google-github-actions/auth@v0.3.1'
+      #   with:
+      #       create_credentials_file: 'true'
+      #       workload_identity_provider: '<example-workload-identity-provider>'
+      #       service_account: '<example-service-account>'
+      # - id: 'gcloud'
+      #   name: 'gcloud'
+      #   run: |-
+      #     gcloud auth login --brief --cred-file="${{ steps.auth.outputs.credentials_file_path }}"
+      #     gcloud services list

--- a/.github/workflows/test-action.yaml
+++ b/.github/workflows/test-action.yaml
@@ -9,6 +9,7 @@ env:
   ARM_CLIENT_ID: "03b75287-e30e-4ac5-813b-ca074c26a325"
   ARM_SUBSCRIPTION_ID: "a267dbd7-a0ac-4f3e-a310-6bb813ff3078"
   ARM_TENANT_ID: "68f381e3-46da-47b9-ba57-6f322b8f0da1"
+  ARM_USE_OIDC: true
 
 permissions:
   id-token: write # This is required for requesting the JWT

--- a/.github/workflows/test-action.yaml
+++ b/.github/workflows/test-action.yaml
@@ -6,9 +6,9 @@ on:
 env:
   AWS_ROLE: "arn:aws:iam::241033177617:role/allow-test-repo"
   AWS_REGION: "us-east-1"
-  AZURE_CLIENT_ID: 
-  AZURE_SUBSCRIPTION_ID:
-  AZURE_TENANT_ID: 
+  AZURE_CLIENT_ID: "03b75287-e30e-4ac5-813b-ca074c26a325"
+  AZURE_SUBSCRIPTION_ID: "a267dbd7-a0ac-4f3e-a310-6bb813ff3078"
+  AZURE_TENANT_ID: "68f381e3-46da-47b9-ba57-6f322b8f0da1"
 
 permissions:
   id-token: write # This is required for requesting the JWT
@@ -40,12 +40,23 @@ jobs:
         run: |
           terraform destroy -auto-approve
 
-      # - name: 'Az CLI login'
-      #   uses: azure/login@v1
-      #   with:
-      #     client-id: ${{ env.AZURE_CLIENT_ID }}
-      #     tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-      #     subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
+      - name: 'Az CLI login'
+        uses: azure/login@v1
+        with:
+          client-id: ${{ env.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Test actions with an Azure backend
+        uses: ./ # Uses an action in the root directory
+        with:
+          working-directory: test/test-azure
+          no-pr: true
+
+      - name: Cleanup Azure test
+        working-directory: test/test-azure
+        run: |
+          terraform destroy -auto-approve
 
       # - id: 'auth'
       #   name: 'Authenticate to GCP'

--- a/action.yml
+++ b/action.yml
@@ -153,6 +153,9 @@ runs:
         # Where to find the terraform
         working_directory="${{ inputs.working-directory }}"
 
+        # Load copy logs script
+        source "./copy_logs.sh"
+
         copy_logs
         status=$?
 

--- a/action.yml
+++ b/action.yml
@@ -62,6 +62,10 @@ inputs:
     description: Associate the run with a specific pull request id. Defaults to finding the ID from the merge commit.
     required: false
     default: ""
+  no-pr:
+    description: Don't require or look up a pull request ID. Skip associated actions
+    required: false
+    default: "false"
   auto-approve:
     description: Auto approve terraform apply
     required: false
@@ -76,13 +80,14 @@ runs:
   using: composite
   steps:
     - name: Find if this push belonged to a PR
-      if: github.event_name == 'push'
+      if: (github.event_name == 'push') && (inputs.no_pr != 'true')
       uses: 8BitJonny/gh-get-current-pr@2.2.0
       id: pr
 
     - name: Consolidate PR ID
       shell: bash
       id: pr_id
+      if: inputs.no_pr != 'true'
       run: |
         if [[ "${{ github.event_name }}" == "push" ]]; then
           if [[ "${{ steps.pr.outputs.pr_found }}" == "false" ]]; then
@@ -161,6 +166,7 @@ runs:
     - name: Comment Apply output to PR
       id: comment-apply
       uses: peter-evans/create-or-update-comment@v2
+      if: inputs.no_pr != 'true'
       with:
         token: ${{ inputs.GITHUB_TOKEN }}
         issue-number: ${{ steps.pr_id.outputs.number }}

--- a/action.yml
+++ b/action.yml
@@ -80,14 +80,14 @@ runs:
   using: composite
   steps:
     - name: Find if this push belonged to a PR
-      if: (github.event_name == 'push') && (inputs.no_pr != 'true')
+      if: (github.event_name == 'push') && (inputs.no-pr != 'true')
       uses: 8BitJonny/gh-get-current-pr@2.2.0
       id: pr
 
     - name: Consolidate PR ID
       shell: bash
       id: pr_id
-      if: inputs.no_pr != 'true'
+      if: inputs.no-pr != 'true'
       run: |
         if [[ "${{ github.event_name }}" == "push" ]]; then
           if [[ "${{ steps.pr.outputs.pr_found }}" == "false" ]]; then
@@ -166,7 +166,7 @@ runs:
     - name: Comment Apply output to PR
       id: comment-apply
       uses: peter-evans/create-or-update-comment@v2
-      if: inputs.no_pr != 'true'
+      if: inputs.no-pr != 'true'
       with:
         token: ${{ inputs.GITHUB_TOKEN }}
         issue-number: ${{ steps.pr_id.outputs.number }}

--- a/action.yml
+++ b/action.yml
@@ -130,41 +130,33 @@ runs:
 
         echo "summary=$(cat apply.log | grep 'Apply complete')" >> "$GITHUB_OUTPUT"
 
-    - name: Generate s3 key name
-      id: s3
+    - name: Copy logs to persistent storage
+      id: copy_logs
       if: inputs.persist-apply-log == true
       shell: bash
-      working-directory: ${{ inputs.working-directory }}
       run: |
-        # Download hcl2json
-        curl -Lo hcl2json $(curl -s https://api.github.com/repos/tmccombs/hcl2json/releases | jq -r '.[] | select(.tag_name == "v0.5.0").assets[] | select(.name == "hcl2json_linux_amd64").browser_download_url')
-        chmod +x hcl2json
 
-        # Get s3 bucket and key by converting terraform backend config to json
-        json=$(./hcl2json *.tf)
+        # Set value for the file to copy
+        source_file="${{ steps.output.outputs.filename }}"
 
-        [[ -z "${{ inputs.s3-bucket }}" ]] \
-          && s3_bucket=$(echo $json | jq -r '.terraform[0].backend.s3[0].bucket') \
-          || s3_bucket=${{ inputs.s3-bucket }}
+        # Set value for the key prefix
+        [[ -n "${{ inputs.key-prefix }}" ]] && key_prefix="${{ inputs.key-prefix }}" || key_prefix="apply_logs"
 
-        [[ -z "${{ inputs.s3-key }}" ]] \
-          && s3_key=$(echo $json | jq -r '.terraform[0].backend.s3[0].key') \
-          || s3_key=${{ inputs.s3-key }}
+        # Set value for the key name
+        [[ -n "${{ inputs.key-name }}" ]] && key_name="${{ inputs.key-name }}" || key_name="${{ github.repository }}/pr-${{ steps.pr_id.outputs.number }}/$(date -u +'%Y-%m-%d/apply-%Y-%m-%dT%H:%M:%SZ.log')"
 
-        echo "S3 bucket: $s3_bucket"
-        echo "S3 key: $s3_key"
+        # Where to find the terraform
+        working_directory="${{ inputs.working-directory }}"
 
-        # Generate s3 key name
-        key="apply_logs/${{ github.repository }}/pr-${{ steps.pr_id.outputs.number }}/$(date -u +'%Y-%m-%d/apply-%Y-%m-%dT%H:%M:%SZ.log')"
-        echo "S3 key name: $key"
+        copy_logs
+        status=$?
 
-        # Copy terraform apply log to s3
-        s3_url="s3://${s3_bucket}/${s3_key}/${key}"
-        aws s3 cp ${{ steps.output.outputs.filename }} $s3_url
-
-        echo "s3_bucket=$s3_bucket" >> $GITHUB_OUTPUT
-        echo "s3_key=$s3_key/$key" >> $GITHUB_OUTPUT
-        echo "s3_url=$s3_url" >> $GITHUB_OUTPUT
+        if [ $status == 0 ]; then
+          echo ${{ steps.copy_logs.outputs.output }}
+        else
+          echo "Wasn't apply to persist apply logs"
+          return $status
+        fi
 
     - name: Comment Apply output to PR
       id: comment-apply

--- a/action.yml
+++ b/action.yml
@@ -126,7 +126,7 @@ runs:
         touch apply.log
         echo "${{ steps.apply.outputs.stdout }}" >> apply.log
         echo "${{ steps.apply.outputs.stderr }}" >> apply.log
-        echo "filename=apply.log" >> $GITHUB_OUTPUT
+        echo "filepath=$(pwd)/apply.log" >> $GITHUB_OUTPUT
 
         EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
         echo "output<<$EOF" >> "$GITHUB_OUTPUT"
@@ -142,7 +142,7 @@ runs:
       run: |
 
         # Set value for the file to copy
-        source_file="${{ steps.output.outputs.filename }}"
+        source_file="${{ steps.output.outputs.filepath }}"
 
         # Set value for the key prefix
         [[ -n "${{ inputs.key-prefix }}" ]] && key_prefix="${{ inputs.key-prefix }}" || key_prefix="apply_logs"

--- a/action.yml
+++ b/action.yml
@@ -30,12 +30,12 @@ inputs:
     description: CLI flags to use with terraform apply
     required: false
     default: ""
-  s3-bucket:
-    description: Override s3 bucket to upload output to. Defaults to the same as the state backend.
   persist-apply-log:
     description: Persist the terraform apply log in long-term storage, by default in the same location as your backend state.
     required: false
     default: "true"
+  bucket:
+    description: Override the bucket name for s3 and gcs to upload output to. Defaults to the same as the state backend, if using s3 or gcp
     required: false
     default: ""
   s3-key:

--- a/action.yml
+++ b/action.yml
@@ -71,9 +71,6 @@ outputs:
   apply_output:
     description: The terraform apply output
     value: ${{ steps.output.outputs.output }}
-  s3_path:
-    description: The S3 URL of the uploaded log file
-    value: ${{ steps.s3.outputs.s3_url }}
 
 runs:
   using: composite

--- a/action.yml
+++ b/action.yml
@@ -137,7 +137,7 @@ runs:
 
     - name: Copy logs to persistent storage
       id: copy_logs
-      if: inputs.persist-apply-log == true
+      if: inputs.persist-apply-log == 'true'
       shell: bash
       run: |
 

--- a/action.yml
+++ b/action.yml
@@ -103,7 +103,7 @@ runs:
         echo "This workflow run is associated with pull request ID: $number"
 
     - name: setup Terraform
-      uses: hashicorp/setup-terraform@v2
+      uses: hashicorp/setup-terraform@v3
       with:
         terraform_version: ${{ inputs.terraform-version }}
 

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,18 @@ inputs:
     description: Override the bucket name for s3 and gcs to upload output to. Defaults to the same as the state backend, if using s3 or gcp
     required: false
     default: ""
+  resource-group-name:
+    description: Override the azurerm resource group to upload output to.
+    required: false
+    default: ""
+  storage-account-name:
+    description: Override the storage account to use to upload output. Defaults to the same as the azurerm backend, if using azurerm.
+    required: false
+    default: ""
+  container-name:
+    description: Override the container into which to upload the output. Defaults to the same as the azurerm backend, if using azurerm.
+    required: false
+    default: ""
   key-path:
     description: Override the path to upload output to. Defaults to the root.
     required: false

--- a/action.yml
+++ b/action.yml
@@ -154,7 +154,7 @@ runs:
         working_directory="${{ inputs.working-directory }}"
 
         # Load copy logs script
-        source "./copy_logs.sh"
+        source "${{github.action_path}}/copy_logs.sh"
 
         copy_logs
         status=$?

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,10 @@ inputs:
     default: ""
   s3-bucket:
     description: Override s3 bucket to upload output to. Defaults to the same as the state backend.
+  persist-apply-log:
+    description: Persist the terraform apply log in long-term storage, by default in the same location as your backend state.
+    required: false
+    default: "true"
     required: false
     default: ""
   s3-key:
@@ -115,6 +119,7 @@ runs:
 
     - name: Generate s3 key name
       id: s3
+      if: inputs.persist-apply-log == true
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |

--- a/action.yml
+++ b/action.yml
@@ -38,8 +38,12 @@ inputs:
     description: Override the bucket name for s3 and gcs to upload output to. Defaults to the same as the state backend, if using s3 or gcp
     required: false
     default: ""
-  s3-key:
-    description: Override s3 object key to upload output to. Defaults to a subdirectory of the statefile key.
+  key-path:
+    description: Override the path to upload output to. Defaults to the root.
+    required: false
+    default: ""
+  key-name:
+    description: Override the filename portion of the key. Defaults to a path merge of the github repo, PR ID, and a timestamp
     required: false
     default: ""
   pr-id:

--- a/action.yml
+++ b/action.yml
@@ -167,7 +167,7 @@ runs:
         body: |
           Terraform Apply: ${{ steps.output.outputs.summary }}
 
-          Full log persisted at: [${{ steps.s3.outputs.s3_url}}](https://s3.console.aws.amazon.com/s3/object/${{ steps.s3.outputs.s3_bucket }}?prefix=${{ steps.s3.outputs.s3_key}})
+          ${{ steps.copy_logs.outputs.output}}
 
           <details open><summary>Show Output</summary>
 
@@ -187,7 +187,7 @@ runs:
 
             Please review the logs and take appropriate action.
 
-            Full log persisted at: [${{ steps.s3.outputs.s3_url}}](https://s3.console.aws.amazon.com/s3/object/${{ steps.s3.outputs.s3_bucket }}?prefix=${{ steps.s3.outputs.s3_key}})
+            ${{ steps.copy_logs.outputs.output}}
 
             <details open><summary>Show Output</summary>
 

--- a/backends/aws/.terraform.lock.hcl
+++ b/backends/aws/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.49.0"
+  constraints = ">= 4.0.0, ~> 5.0"
+  hashes = [
+    "h1:RZtXnBRpO4LNmmz0tXJQLa2heqk9VFGblFZtRCZkm/M=",
+    "zh:0979b07cdeffb868ea605e4bbc008adc7cccb5f3ba1d3a0b794ea3e8fff20932",
+    "zh:2121a0a048a1d9419df69f3561e524b7e8a6b74ba0f57bd8948799f12b6ad3a1",
+    "zh:573362042ba0bd18e98567a4f45d91b09eb0d223513518ba04f16a646a906403",
+    "zh:57be7a4d6c362be2fa586d270203f4eac1ee239816239a9503b86ebc8fa1fef0",
+    "zh:5c72ed211d9234edd70eac9d77c3cafc7bbf819d1c28332a6d77acf227c9a23c",
+    "zh:7786d1a9781f8e8c0079bf58f4ed4aeddec0caf54ad7ddcf43c47936d545a04f",
+    "zh:82133e7d39787ee91ed41988da71beecc2ecb900b5da94b3f3d77fbc4d4dc722",
+    "zh:8cdb1c154dead85be8352afd30eaf41c59249de9e7e0a8eb4ab8e625b90a4922",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:ac215fd1c3bd647ae38868940651b97a53197688daefcd70b3595c84560e5267",
+    "zh:c45db22356d20e431639061a72e07da5201f4937c1df6b9f03f32019facf3905",
+    "zh:c9ba90e62db9a4708ed1a4e094849f88ce9d44c52b49f613b30bb3f7523b8d97",
+    "zh:d2be3607be2209995c80dc1d66086d527de5d470f73509e813254067e8287106",
+    "zh:e3fa20090f3cebf3911fc7ef122bd8c0505e3330ab7d541fa945fea861205007",
+    "zh:ef1b9d5c0b6279323f2ecfc322db8083e141984cfe1bb2f33c0f4934fccb69e3",
+  ]
+}

--- a/backends/aws/main.tf
+++ b/backends/aws/main.tf
@@ -23,7 +23,8 @@ module "github_oidc" {
   ]
 
   managed_policy_arns = [
-    "arn:aws:iam::aws:policy/AmazonS3FullAccess"
+    "arn:aws:iam::aws:policy/AmazonS3FullAccess",
+    "arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess"
   ]
 
   add_oidc_provider = false

--- a/backends/aws/main.tf
+++ b/backends/aws/main.tf
@@ -1,0 +1,34 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~>5"
+    }
+  }
+}
+
+module "state_backend" {
+  source = "github.com/tamu-edu/it-ae-tfmod-aws-state?ref=v0.0.3"
+
+  bucket_name         = "test-it-ae-actions-terraform-pr-apply"
+  dynamodb_table_name = "test-it-ae-actions-terraform-pr-apply"
+}
+
+module "github_oidc" {
+  source = "github.com/tamu-edu/it-ae-tfmod-github-oidc?ref=v1.0.0"
+
+  name = "allow-test-repo"
+  subjects = [
+    "repo:tamu-edu/it-ae-actions-terraform-pr-apply:*"
+  ]
+
+  managed_policy_arns = [
+    "arn:aws:iam::aws:policy/AmazonS3FullAccess"
+  ]
+
+  add_oidc_provider = false
+}
+
+output "role_arn" {
+  value = module.github_oidc.role_arn
+}

--- a/backends/azure/.terraform.lock.hcl
+++ b/backends/azure/.terraform.lock.hcl
@@ -1,0 +1,41 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "3.103.1"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:6bkftpJOwSmA74r2ewWu5JrIoSbwzWRAcsv7S/A+6fs=",
+    "zh:0e78a947c041893a47d2af804f2896d1337cc06230e730e3926db78d416ba883",
+    "zh:21666ab923f659a2fb7a28eee464249acc8617a21eeb4a805fd1acce5f6c0768",
+    "zh:357f7daa2f8cc88394d357192f736b21c2626aa99e31bf0dc0dc2fcf6956e555",
+    "zh:3bfaaa2b1b20841093c44c863bd3cf31068fc6e51b72f85006aa6e656e6555c6",
+    "zh:624d8eea3587b606209cbae89c51070aa85bf4877ea7d4ffeb4cb5d90d0cd3bb",
+    "zh:b66a65f0f60e62b9dc911f5376e7801d481810b8c52ae5e36a58730be0779b8a",
+    "zh:c0362821d82e9a989de4217527f7b9858cd71923508147ae65f47b32ffd85a0e",
+    "zh:ca8d1fc6e67af8970d3655c8f47bccd4e799b2efb5c7ce402ace7462915f30b3",
+    "zh:cd9aa496be3900b447a3c3e041e9d25aa6d10a6b0b4d1ebb1385cd6668d35b50",
+    "zh:d2350210ad53f1dd18ec29b84255aa7b14877e0f1cb5ae77355f9b8ebe2ea209",
+    "zh:f51cbed8c9b225fb346cc42d884c41bf43bb79c90d753e8cf2770362e4689d79",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.6.1"
+  hashes = [
+    "h1:a+Goawwh6Qtg4/bRWzfDtIdrEFfPlnVy0y4LdUQY3nI=",
+    "zh:2a0ec154e39911f19c8214acd6241e469157489fc56b6c739f45fbed5896a176",
+    "zh:57f4e553224a5e849c99131f5e5294be3a7adcabe2d867d8a4fef8d0976e0e52",
+    "zh:58f09948c608e601bd9d0a9e47dcb78e2b2c13b4bda4d8f097d09152ea9e91c5",
+    "zh:5c2a297146ed6fb3fe934c800e78380f700f49ff24dbb5fb5463134948e3a65f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7ce41e26f0603e31cdac849085fc99e5cd5b3b73414c6c6d955c0ceb249b593f",
+    "zh:8c9e8d30c4ef08ee8bcc4294dbf3c2115cd7d9049c6ba21422bd3471d92faf8a",
+    "zh:93e91be717a7ffbd6410120eb925ebb8658cc8f563de35a8b53804d33c51c8b0",
+    "zh:982542e921970d727ce10ed64795bf36c4dec77a5db0741d4665230d12250a0d",
+    "zh:b9d1873f14d6033e216510ef541c891f44d249464f13cc07d3f782d09c7d18de",
+    "zh:cfe27faa0bc9556391c8803ade135a5856c34a3fe85b9ae3bdd515013c0c87c1",
+    "zh:e4aabf3184bbb556b89e4b195eab1514c86a2914dd01c23ad9813ec17e863a8a",
+  ]
+}

--- a/backends/azure/main.tf
+++ b/backends/azure/main.tf
@@ -12,5 +12,4 @@ module "state_backend" {
 
   storage_account_name = "itaeactionstfapply"
   container_name       = "itaeactionstfapply"
-  location             = "southcentralus"
 }

--- a/backends/azure/main.tf
+++ b/backends/azure/main.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_providers {
+    azure = {
+      source  = "hashicorp/azurerm"
+      version = "~>3"
+    }
+  }
+}
+
+module "state_backend" {
+  source = "github.com/tamu-edu/it-ae-tfmod-azure-state?ref=v0.1.1"
+
+  storage_account_name = "itaeactionstfapply"
+  container_name       = "itaeactionstfapply"
+  location             = "southcentralus"
+}

--- a/copy_logs.sh
+++ b/copy_logs.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+copy_logs () {
+
+  # Setup pull key path
+  key="$key_prefix/$key_name"
+
+  backend_config="${working_directory}/.terraform/terraform.tfstate"
+  backend_type=$(jq -r '.backend.type' $backend_config)
+
+  # Output locally if not in github actions
+  if [[ -z $GITHUB_OUTPUT ]]; then
+    GITHUB_OUTPUT="./github_actions.out"
+    true > $GITHUB_OUTPUT
+  fi
+
+  # Setting output for github actions
+  echo "backend_type=$backend_type" >> $GITHUB_OUTPUT
+
+  case $backend_type in
+    s3)
+      [[ -z $bucket ]] && bucket=$(jq -r '.backend.config.bucket' $backend_config)
+      s3_url="s3://${bucket}/${key}"
+
+      output="Copying apply log to AWS S3 at $s3_url"
+      echo "$output"
+
+      # Setting outputs for github actions
+      echo "bucket=$bucket" >> $GITHUB_OUTPUT
+      echo "key=$key" >> $GITHUB_OUTPUT
+      echo "s3_url=$s3_url" >> $GITHUB_OUTPUT
+      echo "output=$output" >> $GITHUB_OUTPUT
+
+      [[ ! $dryrun ]] && aws s3 cp "${source_file}" "${s3_url}"
+      return
+      ;;
+
+    azurerm)
+      [[ -z $resource_group_name ]]  && resource_group_name=$(jq -r '.backend.config.bucket' $backend_config)
+      [[ -z $storage_account_name ]] && storage_account_name=$(jq -r '.backend.config.bucket' $backend_config)
+      [[ -z $container ]]            && container=$(jq -r '.backend.config.bucket' $backend_config)
+
+      output="Copying apply log to Azure at $storage_account_name / $container at $key"
+      echo $output
+
+      # Setting outputs for github actions
+      echo "resource_group_name=$resource_group_name" >> $GITHUB_OUTPUT
+      echo "storage_account_name=$storage_account_name" >> $GITHUB_OUTPUT
+      echo "key=$key" >> $GITHUB_OUTPUT
+      echo "container=$container" >> $GITHUB_OUTPUT
+      echo "output=$output" >> $GITHUB_OUTPUT
+
+      [[ ! $dryrun ]] && az storage azcopy blob upload --container "$container" --account-name "$storage_account_name" --source "${source_file}" --destination "$key"
+      return
+      ;;
+
+    gcs)
+      [[ -z $bucket ]] && bucket=$(jq -r '.backend.config.bucket' $backend_config)
+      gs_url="gs://${bucket}/${key}"
+
+      output="Copying apply log to GCP at $gs_url"
+      echo $output
+
+      # Setting outputs for github actions
+      echo "bucket=$bucket" >> $GITHUB_OUTPUT
+      echo "key=$key" >> $GITHUB_OUTPUT
+      echo "gs_url=$gs_url" >> $GITHUB_OUTPUT
+      echo "output=$output" >> $GITHUB_OUTPUT
+
+      [[ ! $dryrun ]] && gsutil cp "${source_file}" "${gs_url}"
+      return
+      ;;
+
+    
+    *)
+      echo "The backend type could not be determined or isn't supported ($backend_type)"
+  esac
+}

--- a/copy_logs.sh
+++ b/copy_logs.sh
@@ -36,9 +36,9 @@ copy_logs () {
       ;;
 
     azurerm)
-      [[ -z $resource_group_name ]]  && resource_group_name=$(jq -r '.backend.config.bucket' $backend_config)
-      [[ -z $storage_account_name ]] && storage_account_name=$(jq -r '.backend.config.bucket' $backend_config)
-      [[ -z $container ]]            && container=$(jq -r '.backend.config.bucket' $backend_config)
+      [[ -z $resource_group_name ]]  && resource_group_name=$(jq -r '.backend.config.resource_group_name' $backend_config)
+      [[ -z $storage_account_name ]] && storage_account_name=$(jq -r '.backend.config.storage_account_name' $backend_config)
+      [[ -z $container ]]            && container=$(jq -r '.backend.config.container_name' $backend_config)
 
       output="Copying apply log to Azure at $storage_account_name / $container at $key"
       echo $output

--- a/test/apply_logs.txt
+++ b/test/apply_logs.txt
@@ -1,0 +1,1 @@
+test log file

--- a/test/assert.sh
+++ b/test/assert.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+
+#####################################################################
+##
+## title: Assert Extension
+##
+## description:
+## Assert extension of shell (bash, ...)
+##   with the common assert functions
+## Function list based on:
+##   http://junit.sourceforge.net/javadoc/org/junit/Assert.html
+## Log methods : inspired by
+##	- https://natelandau.com/bash-scripting-utilities/
+## author: Mark Torok
+##
+## date: 07. Dec. 2016
+##
+## license: MIT
+##
+#####################################################################
+
+if command -v tput &>/dev/null && tty -s; then
+  RED=$(tput setaf 1)
+  GREEN=$(tput setaf 2)
+  MAGENTA=$(tput setaf 5)
+  NORMAL=$(tput sgr0)
+  BOLD=$(tput bold)
+else
+  RED=$(echo -en "\e[31m")
+  GREEN=$(echo -en "\e[32m")
+  MAGENTA=$(echo -en "\e[35m")
+  NORMAL=$(echo -en "\e[00m")
+  BOLD=$(echo -en "\e[01m")
+fi
+
+log_header() {
+  printf "\n${BOLD}${MAGENTA}==========  %s  ==========${NORMAL}\n" "$@" >&2
+}
+
+log_success() {
+  printf "${GREEN}✔ %s${NORMAL}\n" "$@" >&2
+}
+
+log_failure() {
+  printf "${RED}✖ %s${NORMAL}\n" "$@" >&2
+}
+
+
+assert_eq() {
+  local expected="$1"
+  local actual="$2"
+  local msg="${3-}"
+
+  if [ "$expected" == "$actual" ]; then
+    return 0
+  else
+    [ "${#msg}" -gt 0 ] && log_failure "$expected == $actual :: $msg" || true
+    return 1
+  fi
+}
+
+assert_not_eq() {
+  local expected="$1"
+  local actual="$2"
+  local msg="${3-}"
+
+  if [ ! "$expected" == "$actual" ]; then
+    return 0
+  else
+    [ "${#msg}" -gt 0 ] && log_failure "$expected != $actual :: $msg" || true
+    return 1
+  fi
+}
+
+assert_true() {
+  local actual="$1"
+  local msg="${2-}"
+
+  assert_eq true "$actual" "$msg"
+  return "$?"
+}
+
+assert_false() {
+  local actual="$1"
+  local msg="${2-}"
+
+  assert_eq false "$actual" "$msg"
+  return "$?"
+}
+
+assert_array_eq() {
+
+  declare -a expected=("${!1-}")
+  # echo "AAE ${expected[@]}"
+
+  declare -a actual=("${!2}")
+  # echo "AAE ${actual[@]}"
+
+  local msg="${3-}"
+
+  local return_code=0
+  if [ ! "${#expected[@]}" == "${#actual[@]}" ]; then
+    return_code=1
+  fi
+
+  local i
+  for (( i=1; i < ${#expected[@]} + 1; i+=1 )); do
+    if [ ! "${expected[$i-1]}" == "${actual[$i-1]}" ]; then
+      return_code=1
+      break
+    fi
+  done
+
+  if [ "$return_code" == 1 ]; then
+    [ "${#msg}" -gt 0 ] && log_failure "(${expected[*]}) != (${actual[*]}) :: $msg" || true
+  fi
+
+  return "$return_code"
+}
+
+assert_array_not_eq() {
+
+  declare -a expected=("${!1-}")
+  declare -a actual=("${!2}")
+
+  local msg="${3-}"
+
+  local return_code=1
+  if [ ! "${#expected[@]}" == "${#actual[@]}" ]; then
+    return_code=0
+  fi
+
+  local i
+  for (( i=1; i < ${#expected[@]} + 1; i+=1 )); do
+    if [ ! "${expected[$i-1]}" == "${actual[$i-1]}" ]; then
+      return_code=0
+      break
+    fi
+  done
+
+  if [ "$return_code" == 1 ]; then
+    [ "${#msg}" -gt 0 ] && log_failure "(${expected[*]}) == (${actual[*]}) :: $msg" || true
+  fi
+
+  return "$return_code"
+}
+
+assert_empty() {
+  local actual=$1
+  local msg="${2-}"
+
+  assert_eq "" "$actual" "$msg"
+  return "$?"
+}
+
+assert_not_empty() {
+  local actual=$1
+  local msg="${2-}"
+
+  assert_not_eq "" "$actual" "$msg"
+  return "$?"
+}
+
+assert_contain() {
+  local haystack="$1"
+  local needle="${2-}"
+  local msg="${3-}"
+
+  if [ -z "${needle:+x}" ]; then
+    return 0;
+  fi
+
+  if [ -z "${haystack##*$needle*}" ]; then
+    return 0
+  else
+    [ "${#msg}" -gt 0 ] && log_failure "$haystack doesn't contain $needle :: $msg" || true
+    return 1
+  fi
+}
+
+assert_not_contain() {
+  local haystack="$1"
+  local needle="${2-}"
+  local msg="${3-}"
+
+  if [ -z "${needle:+x}" ]; then
+    return 0;
+  fi
+
+  if [ "${haystack##*$needle*}" ]; then
+    return 0
+  else
+    [ "${#msg}" -gt 0 ] && log_failure "$haystack contains $needle :: $msg" || true
+    return 1
+  fi
+}
+
+assert_gt() {
+  local first="$1"
+  local second="$2"
+  local msg="${3-}"
+
+  if [[ "$first" -gt  "$second" ]]; then
+    return 0
+  else
+    [ "${#msg}" -gt 0 ] && log_failure "$first > $second :: $msg" || true
+    return 1
+  fi
+}
+
+assert_ge() {
+  local first="$1"
+  local second="$2"
+  local msg="${3-}"
+
+  if [[ "$first" -ge  "$second" ]]; then
+    return 0
+  else
+    [ "${#msg}" -gt 0 ] && log_failure "$first >= $second :: $msg" || true
+    return 1
+  fi
+}
+
+assert_lt() {
+  local first="$1"
+  local second="$2"
+  local msg="${3-}"
+
+  if [[ "$first" -lt  "$second" ]]; then
+    return 0
+  else
+    [ "${#msg}" -gt 0 ] && log_failure "$first < $second :: $msg" || true
+    return 1
+  fi
+}
+
+assert_le() {
+  local first="$1"
+  local second="$2"
+  local msg="${3-}"
+
+  if [[ "$first" -le  "$second" ]]; then
+    return 0
+  else
+    [ "${#msg}" -gt 0 ] && log_failure "$first <= $second :: $msg" || true
+    return 1
+  fi
+}

--- a/test/github_actions.out
+++ b/test/github_actions.out
@@ -1,0 +1,5 @@
+backend_type=azurerm
+resource_group_name=my-resource-group
+storage_account_name=my-storage-account
+key=apply_logs/override-key-name
+container=my-storage-container

--- a/test/test-aws/main.tf
+++ b/test/test-aws/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~>5"
+    }
+  }
+
+  backend "s3" {
+    bucket         = "test-it-ae-actions-terraform-pr-apply"
+    key            = "terraform.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "test-it-ae-actions-terraform-pr-apply"
+  }
+}
+
+resource "aws_s3_bucket" "test_bucket" {
+  bucket = "test-it-ae-actions-terraform-pr-apply-test-bucket"
+}

--- a/test/test-azure/main.tf
+++ b/test/test-azure/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~>3"
+    }
+  }
+
+  backend "azurerm" {
+    resource_group_name  = "itaeactionstfapply"
+    storage_account_name = "itaeactionstfapply"
+    container_name       = "itaeactionstfapply"
+    location             = "southcentralus"
+  }
+}
+
+resource "azurerm_storage_account" "test_storage_account" {
+  name                     = "itaeactionstfapplytest"
+  resource_group_name      = "itaeactionstfapplytest"
+  location                 = "southcentralus"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}

--- a/test/test-azure/main.tf
+++ b/test/test-azure/main.tf
@@ -7,16 +7,19 @@ terraform {
   }
 
   backend "azurerm" {
-    resource_group_name  = "itaeactionstfapply"
+    resource_group_name  = "terraform-state"
     storage_account_name = "itaeactionstfapply"
     container_name       = "itaeactionstfapply"
-    location             = "southcentralus"
+    key                  = "terraform.tfstate"
   }
+}
+provider "azurerm" {
+  features {}
 }
 
 resource "azurerm_storage_account" "test_storage_account" {
   name                     = "itaeactionstfapplytest"
-  resource_group_name      = "itaeactionstfapplytest"
+  resource_group_name      = "terraform-state"
   location                 = "southcentralus"
   account_tier             = "Standard"
   account_replication_type = "LRS"

--- a/test/test.sh
+++ b/test/test.sh
@@ -14,8 +14,7 @@ source ../copy_logs.sh
 
 # AWS S3
 
-working_directory="test-s3"
-
+working_directory="test-aws"
 bucket="my-terraform-state-bucket"
 
 test_name="S3 backend with all values from terraform"

--- a/test/test.sh
+++ b/test/test.sh
@@ -5,7 +5,6 @@ dryrun=true
 source_file="apply_logs.txt"
 # [[ -n "${{ inputs.key-prefix }}" ]] && key_prefix="${{ inputs.key-prefix }}" || key_prefix="apply_logs"
 key_prefix="apply_logs"
-bucket="my-terraform-state-bucket"
 #  [[ -n "${{ inputs.key-name }}" ]] && key_name="${{ inputs.key-name }}" || key_name="${{ github.repository }}/pr-${{ steps.pr_id.outputs.number }}/$(date -u +'%Y-%m-%d/apply-%Y-%m-%dT%H:%M:%SZ.log')"
 key_name="tamu-edu/test-repo/pr-21/$(date -u +'%Y-%m-%d/apply-%Y-%m-%dT%H:%M:%SZ.log')"
 
@@ -19,6 +18,7 @@ source ../copy_logs.sh
 
 working_directory="test-s3"
 
+bucket="my-terraform-state-bucket"
 
 test_name="S3 backend with all values from terraform"
 output=$(copy_logs)

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+source './assert.sh'
+
+dryrun=true
+source_file="apply_logs.txt"
+# [[ -n "${{ inputs.key-prefix }}" ]] && key_prefix="${{ inputs.key-prefix }}" || key_prefix="apply_logs"
+key_prefix="apply_logs"
+bucket="my-terraform-state-bucket"
+#  [[ -n "${{ inputs.key-name }}" ]] && key_name="${{ inputs.key-name }}" || key_name="${{ github.repository }}/pr-${{ steps.pr_id.outputs.number }}/$(date -u +'%Y-%m-%d/apply-%Y-%m-%dT%H:%M:%SZ.log')"
+key_name="tamu-edu/test-repo/pr-21/$(date -u +'%Y-%m-%d/apply-%Y-%m-%dT%H:%M:%SZ.log')"
+
+test_output () {
+  [ "$?" == 0 ] && log_success "$test_name" || echo $(log_failure "$test_name" && echo "$output != $expected")
+}
+
+source ../copy_logs.sh
+
+# AWS S3
+
+working_directory="test-s3"
+
+
+test_name="S3 backend with all values from terraform"
+output=$(copy_logs)
+assert_eq "$output" "Copying apply log to AWS S3 at s3://$bucket/$key_prefix/$key_name"
+test_output
+
+test_name="S3 backend with override bucket"
+override="override-bucket-name"
+output=$(bucket="$override" copy_logs)
+assert_eq "$output" "Copying apply log to AWS S3 at s3://$override/$key_prefix/$key_name"
+test_output
+
+test_name="S3 backend with override key_prefix"
+override="override-key-prefix"
+output=$(key_prefix="$override" copy_logs)
+expected="Copying apply log to AWS S3 at s3://$bucket/$override/$key_name"
+assert_eq "$output" "$expected"
+test_output
+
+test_name="S3 backend with override key_name"
+override="custom-key-name"
+output=$(key_name="$override" copy_logs)
+expected="Copying apply log to AWS S3 at s3://$bucket/$key_prefix/$override"
+assert_eq "$output" "$expected"
+test_output
+
+
+# Azure RM
+working_directory="test-azurerm"
+resource_group_name="my-resource-group"
+storage_account_name="my-storage-account"
+container="my-storage-container"
+
+test_name="Azure backend with all values from terraform"
+output=$(copy_logs)
+assert_eq "$output" "Copying apply log to Azure at $storage_account_name / $container at $key_prefix/$key_name"
+test_output
+
+test_name="Azure backend with override resource group"
+override="override-resource-group"
+output=$(resource_group_name="$override" copy_logs)
+assert_eq "$output" "Copying apply log to Azure at $storage_account_name / $container at $key_prefix/$key_name"
+test_output
+
+test_name="Azure backend with override storage account"
+override="override-storage-account"
+output=$(storage_account_name="$override" copy_logs)
+assert_eq "$output" "Copying apply log to Azure at $override / $container at $key_prefix/$key_name"
+test_output
+
+test_name="Azure backend with override container"
+override="override-container"
+output=$(container="$override" copy_logs)
+assert_eq "$output" "Copying apply log to Azure at $storage_account_name / $override at $key_prefix/$key_name"
+test_output
+
+test_name="Azure backend with override key_prefix"
+override="override-key-prefix"
+output=$(key_prefix="$override" copy_logs)
+assert_eq "$output" "Copying apply log to Azure at $storage_account_name / $container at $override/$key_name"
+test_output
+
+test_name="Azure backend with override key_name"
+override="override-key-name"
+output=$(key_name="$override" copy_logs)
+assert_eq "$output" "Copying apply log to Azure at $storage_account_name / $container at $key_prefix/$override"
+test_output

--- a/test/test.sh
+++ b/test/test.sh
@@ -3,9 +3,7 @@ source './assert.sh'
 
 dryrun=true
 source_file="apply_logs.txt"
-# [[ -n "${{ inputs.key-prefix }}" ]] && key_prefix="${{ inputs.key-prefix }}" || key_prefix="apply_logs"
 key_prefix="apply_logs"
-#  [[ -n "${{ inputs.key-name }}" ]] && key_name="${{ inputs.key-name }}" || key_name="${{ github.repository }}/pr-${{ steps.pr_id.outputs.number }}/$(date -u +'%Y-%m-%d/apply-%Y-%m-%dT%H:%M:%SZ.log')"
 key_name="tamu-edu/test-repo/pr-21/$(date -u +'%Y-%m-%d/apply-%Y-%m-%dT%H:%M:%SZ.log')"
 
 test_output () {


### PR DESCRIPTION
Terraform will create a `.terraform/terraform.tfstate` file after `terraform init` that contains the full backend config object, which simplifies having to parse local hcl files then check for partial config flags.

This PR refactors the backend scraping to use this file, then adds support for using azcopy and gsutils for copying the apply logs to azure and GCP respectively. It will auto-detect which backend is in use and all necessary backend parameters for the copy.