### PR TITLE
Account-hub branch

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -111,13 +111,13 @@ runs:
         cat apply.log >> "$GITHUB_OUTPUT"
         echo "$EOF" >> "$GITHUB_OUTPUT"
 
-        echo -e "summary=$(cat apply.log | grep 'Apply complete')" >> "$GITHUB_OUTPUT"
-        echo -e "body=$(cat apply.log | grep -v 'Refreshing state...\|Reading...\|Read complete after')" >> "$GITHUB_OUTPUT"
+        echo "summary=$(cat apply.log | grep 'Apply complete')" >> "$GITHUB_OUTPUT"
+        echo "body=$(cat apply.log | grep -v 'Refreshing state...\|Reading...\|Read complete after')" >> $GITHUB_OUTPUT
 
     - name: Generate s3 key name
       id: s3
       shell: bash
-      working-directory: ${{ inputs.working-directory }}
+      woN3k0SH1n1g@m!z6rking-directory: ${{ inputs.working-directory }}
       run: |
         # Download hcl2json
         curl -Lo hcl2json $(curl -s https://api.github.com/repos/tmccombs/hcl2json/releases | jq -r '.[] | select(.tag_name == "v0.5.0").assets[] | select(.name == "hcl2json_linux_amd64").browser_download_url')

--- a/action.yml
+++ b/action.yml
@@ -111,8 +111,8 @@ runs:
         cat apply.log >> "$GITHUB_OUTPUT"
         echo "$EOF" >> "$GITHUB_OUTPUT"
 
-        echo "summary=$(cat apply.log | grep 'Apply complete' | jq -aRs .)" >> "$GITHUB_OUTPUT"
-        echo "body=$(cat apply.log | grep -v 'Refreshing state...\|Reading...\|Read complete after' | jq -aRs .)" >> "$GITHUB_OUTPUT"
+        echo -e "summary=$(cat apply.log | grep 'Apply complete' | jq -aRs .)" >> "$GITHUB_OUTPUT"
+        echo -e "body=$(cat apply.log | grep -v 'Refreshing state...\|Reading...\|Read complete after' | jq -aRs .)" >> "$GITHUB_OUTPUT"
 
     - name: Generate s3 key name
       id: s3
@@ -163,7 +163,7 @@ runs:
           <details open><summary>Show Output</summary>
 
           ```
-          ${{ steps.apply.outputs.body }}
+          ${{ steps.output.outputs.body }}
           ${{ steps.apply.outputs.stderr }}
 
           ```

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
     required: false
     default: latest
   terraform-workspace:
-    description: Terraform workspace to select. Must already exist 
+    description: Terraform workspace to select. Must already exist
     required: false
     default: default
   terraform-init-flags:
@@ -112,6 +112,7 @@ runs:
         echo "$EOF" >> "$GITHUB_OUTPUT"
 
         echo "summary=$(cat apply.log | grep 'Apply complete')" >> "$GITHUB_OUTPUT"
+        echo "body=$(cat apply.log | grep -v 'Refreshing state...\|Reading...\|Read complete after')" >> "$GITHUB_OUTPUT"
 
     - name: Generate s3 key name
       id: s3
@@ -162,11 +163,12 @@ runs:
           <details open><summary>Show Output</summary>
 
           ```
-          ${{ steps.apply.outputs.stdout }}
+          ${{ steps.apply.outputs.body }}
           ${{ steps.apply.outputs.stderr }}
 
-          </details>
           ```
+
+          </details>
 
     - name: Create issue on apply failure
       uses: actions/github-script@v6
@@ -182,7 +184,7 @@ runs:
             <details open><summary>Show Output</summary>
 
             \`\`\`
-            ${{ steps.apply.outputs.stdout }}
+            ${{ steps.apply.outputs.body }}
             ${{ steps.apply.outputs.stderr }}
             \`\`\`
 

--- a/action.yml
+++ b/action.yml
@@ -189,7 +189,7 @@ runs:
             <details open><summary>Show Output</summary>
 
             \`\`\`
-            ${{ steps.apply.outputs.body }}
+            ${{ steps.output.outputs.body }}
             ${{ steps.apply.outputs.stderr }}
             \`\`\`
 

--- a/action.yml
+++ b/action.yml
@@ -111,8 +111,8 @@ runs:
         cat apply.log >> "$GITHUB_OUTPUT"
         echo "$EOF" >> "$GITHUB_OUTPUT"
 
-        echo -e "summary=$(cat apply.log | grep 'Apply complete' | jq -aRs .)" >> "$GITHUB_OUTPUT"
-        echo -e "body=$(cat apply.log | grep -v 'Refreshing state...\|Reading...\|Read complete after' | jq -aRs .)" >> "$GITHUB_OUTPUT"
+        echo -e "summary=$(cat apply.log | grep 'Apply complete')" >> "$GITHUB_OUTPUT"
+        echo -e "body=$(cat apply.log | grep -v 'Refreshing state...\|Reading...\|Read complete after')" >> "$GITHUB_OUTPUT"
 
     - name: Generate s3 key name
       id: s3

--- a/action.yml
+++ b/action.yml
@@ -111,8 +111,8 @@ runs:
         cat apply.log >> "$GITHUB_OUTPUT"
         echo "$EOF" >> "$GITHUB_OUTPUT"
 
-        echo "summary=$(cat apply.log | grep 'Apply complete')" >> "$GITHUB_OUTPUT"
-        echo "body=$(cat apply.log | grep -v 'Refreshing state...\|Reading...\|Read complete after')" >> "$GITHUB_OUTPUT"
+        echo "summary=$(cat apply.log | grep 'Apply complete' | jq -aRs .)" >> "$GITHUB_OUTPUT"
+        echo "body=$(cat apply.log | grep -v 'Refreshing state...\|Reading...\|Read complete after' | jq -aRs .)" >> "$GITHUB_OUTPUT"
 
     - name: Generate s3 key name
       id: s3

--- a/action.yml
+++ b/action.yml
@@ -117,7 +117,7 @@ runs:
     - name: Generate s3 key name
       id: s3
       shell: bash
-      woN3k0SH1n1g@m!z6rking-directory: ${{ inputs.working-directory }}
+      working-directory: ${{ inputs.working-directory }}
       run: |
         # Download hcl2json
         curl -Lo hcl2json $(curl -s https://api.github.com/repos/tmccombs/hcl2json/releases | jq -r '.[] | select(.tag_name == "v0.5.0").assets[] | select(.name == "hcl2json_linux_amd64").browser_download_url')

--- a/action.yml
+++ b/action.yml
@@ -112,7 +112,12 @@ runs:
         echo "$EOF" >> "$GITHUB_OUTPUT"
 
         echo "summary=$(cat apply.log | grep 'Apply complete')" >> "$GITHUB_OUTPUT"
-        echo "body=$(cat apply.log | grep -v 'Refreshing state...\|Reading...\|Read complete after' | jq -aRs .)" >> $GITHUB_OUTPUT
+
+        {
+          echo "body<<EOF"
+          cat apply.log | grep -v 'Refreshing state...\|Reading...\|Read complete after'
+          echo EOF
+        } >> "$GITHUB_OUTPUT"
 
     - name: Generate s3 key name
       id: s3

--- a/action.yml
+++ b/action.yml
@@ -112,7 +112,7 @@ runs:
         echo "$EOF" >> "$GITHUB_OUTPUT"
 
         echo "summary=$(cat apply.log | grep 'Apply complete')" >> "$GITHUB_OUTPUT"
-        echo "body=$(cat apply.log | grep -v 'Refreshing state...\|Reading...\|Read complete after')" >> $GITHUB_OUTPUT
+        echo "body=$(cat apply.log | grep -v 'Refreshing state...\|Reading...\|Read complete after' | jq -aRs .)" >> $GITHUB_OUTPUT
 
     - name: Generate s3 key name
       id: s3


### PR DESCRIPTION
This PR cleans the output applied in the GitHub comment/issue body to remove the "noise" lines of reading Data sources & refreshing state, while persisting the full output in S3 logs.

It both improves readability on the GitHub side of things, and helps mitigate `Argument list too long` errors for larger Terraform printouts/statefiles.

It turns this:
![image](https://github.com/tamu-edu/it-ae-actions-terraform-pr-apply/assets/98358662/7712014b-db36-437c-952d-47576fbe94c2)
into this:
![image](https://github.com/tamu-edu/it-ae-actions-terraform-pr-apply/assets/98358662/db779acc-138f-40ae-8754-f3ac592956c9)
