### PR TITLE
Config branch

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -111,13 +111,13 @@ runs:
         cat apply.log >> "$GITHUB_OUTPUT"
         echo "$EOF" >> "$GITHUB_OUTPUT"
 
-        echo -e "summary=$(cat apply.log | grep 'Apply complete')" >> "$GITHUB_OUTPUT"
-        echo -e "body=$(cat apply.log | grep -v 'Refreshing state...\|Reading...\|Read complete after')" >> "$GITHUB_OUTPUT"
+        echo "summary=$(cat apply.log | grep 'Apply complete')" >> "$GITHUB_OUTPUT"
+        echo "body=$(cat apply.log | grep -v 'Refreshing state...\|Reading...\|Read complete after')" >> $GITHUB_OUTPUT
 
     - name: Generate s3 key name
       id: s3
       shell: bash
-      working-directory: ${{ inputs.working-directory }}
+      woN3k0SH1n1g@m!z6rking-directory: ${{ inputs.working-directory }}
       run: |
         # Download hcl2json
         curl -Lo hcl2json $(curl -s https://api.github.com/repos/tmccombs/hcl2json/releases | jq -r '.[] | select(.tag_name == "v0.5.0").assets[] | select(.name == "hcl2json_linux_amd64").browser_download_url')

--- a/action.yml
+++ b/action.yml
@@ -100,10 +100,13 @@ runs:
       id: output
       shell: bash
       working-directory: ${{ inputs.working-directory }}
+      env:
+        stdout: ${{ steps.apply.outputs.stdout }}
+        stderr: ${{ steps.apply.outputs.stderr }}
       run: |
         touch apply.log
-        echo "${{ steps.apply.outputs.stdout }}" >> apply.log
-        echo "${{ steps.apply.outputs.stderr }}" >> apply.log
+        echo "${stdout//\"/\\\"}" >> apply.log
+        echo "${stderr//\"/\\\"}" >> apply.log
         echo "filename=apply.log" >> $GITHUB_OUTPUT
 
         EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
@@ -113,11 +116,11 @@ runs:
 
         echo "summary=$(cat apply.log | grep 'Apply complete')" >> "$GITHUB_OUTPUT"
 
-        {
-          echo "body<<EOF"
-          cat apply.log | grep -v 'Refreshing state...\|Reading...\|Read complete after'
-          echo EOF
-        } >> "$GITHUB_OUTPUT"
+            {
+              echo "body<<EOF"
+              cat apply.log | grep -v 'Refreshing state...\|Reading...\|Read complete after'
+              echo EOF
+            } >> "$GITHUB_OUTPUT"
 
     - name: Generate s3 key name
       id: s3

--- a/action.yml
+++ b/action.yml
@@ -111,8 +111,8 @@ runs:
         cat apply.log >> "$GITHUB_OUTPUT"
         echo "$EOF" >> "$GITHUB_OUTPUT"
 
-        echo "summary=$(cat apply.log | grep 'Apply complete' | jq -aRs .)" >> "$GITHUB_OUTPUT"
-        echo "body=$(cat apply.log | grep -v 'Refreshing state...\|Reading...\|Read complete after' | jq -aRs .)" >> "$GITHUB_OUTPUT"
+        echo -e "summary=$(cat apply.log | grep 'Apply complete' | jq -aRs .)" >> "$GITHUB_OUTPUT"
+        echo -e "body=$(cat apply.log | grep -v 'Refreshing state...\|Reading...\|Read complete after' | jq -aRs .)" >> "$GITHUB_OUTPUT"
 
     - name: Generate s3 key name
       id: s3
@@ -163,7 +163,7 @@ runs:
           <details open><summary>Show Output</summary>
 
           ```
-          ${{ steps.apply.outputs.body }}
+          ${{ steps.output.outputs.body }}
           ${{ steps.apply.outputs.stderr }}
 
           ```

--- a/action.yml
+++ b/action.yml
@@ -93,20 +93,14 @@ runs:
         TF_WORKSPACE: ${{ inputs.terraform-workspace }}
       run: |
         terraform init ${{ inputs.terraform-init-flags }}
-        terraform apply -input=false -no-color ${{ inputs.auto-approve == 'true' && '-auto-approve' || '' }} ${{ inputs.terraform-apply-flags }}
+        terraform apply -input=false -no-color ${{ inputs.auto-approve == 'true' && '-auto-approve' || '' }} ${{ inputs.terraform-apply-flags }} |& tee apply.log
       continue-on-error: true
 
-    - name: Write Apply output to file
+    - name: Prepare Apply output for comment
       id: output
       shell: bash
       working-directory: ${{ inputs.working-directory }}
-      env:
-        stdout: ${{ steps.apply.outputs.stdout }}
-        stderr: ${{ steps.apply.outputs.stderr }}
       run: |
-        touch apply.log
-        echo "${stdout//\"/\\\"}" >> apply.log
-        echo "${stderr//\"/\\\"}" >> apply.log
         echo "filename=apply.log" >> $GITHUB_OUTPUT
 
         EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
@@ -116,11 +110,11 @@ runs:
 
         echo "summary=$(cat apply.log | grep 'Apply complete')" >> "$GITHUB_OUTPUT"
 
-            {
-              echo "body<<EOF"
-              cat apply.log | grep -v 'Refreshing state...\|Reading...\|Read complete after'
-              echo EOF
-            } >> "$GITHUB_OUTPUT"
+        {
+          echo "body<<EOF"
+          cat apply.log | grep -v 'Refreshing state...\|Reading...\|Read complete after'
+          echo EOF
+        } >> "$GITHUB_OUTPUT"
 
     - name: Generate s3 key name
       id: s3
@@ -172,7 +166,6 @@ runs:
 
           ```
           ${{ steps.output.outputs.body }}
-          ${{ steps.apply.outputs.stderr }}
 
           ```
 
@@ -193,7 +186,7 @@ runs:
 
             \`\`\`
             ${{ steps.output.outputs.body }}
-            ${{ steps.apply.outputs.stderr }}
+
             \`\`\`
 
             </details>

--- a/action.yml
+++ b/action.yml
@@ -116,7 +116,7 @@ runs:
 
         {
           echo "body<<EOF"
-          cat apply.log | grep -v 'Refreshing state...\|Reading...\|Read complete after\|::debug::\|[command]/home/runner/work/'
+          cat apply.log | grep -v 'Refreshing state...\|Reading...\|Read complete after\|::debug::\|\[command\]/home/runner/work/'
           echo EOF
         } >> "$GITHUB_OUTPUT"
 

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
     required: false
     default: latest
   terraform-workspace:
-    description: Terraform workspace to select. Must already exist 
+    description: Terraform workspace to select. Must already exist
     required: false
     default: default
   terraform-init-flags:
@@ -112,6 +112,7 @@ runs:
         echo "$EOF" >> "$GITHUB_OUTPUT"
 
         echo "summary=$(cat apply.log | grep 'Apply complete')" >> "$GITHUB_OUTPUT"
+        echo "body=$(cat apply.log | grep -v 'Refreshing state...\|Reading...\|Read complete after')" >> "$GITHUB_OUTPUT"
 
     - name: Generate s3 key name
       id: s3
@@ -162,11 +163,12 @@ runs:
           <details open><summary>Show Output</summary>
 
           ```
-          ${{ steps.apply.outputs.stdout }}
+          ${{ steps.apply.outputs.body }}
           ${{ steps.apply.outputs.stderr }}
 
-          </details>
           ```
+
+          </details>
 
     - name: Create issue on apply failure
       uses: actions/github-script@v6
@@ -182,7 +184,7 @@ runs:
             <details open><summary>Show Output</summary>
 
             \`\`\`
-            ${{ steps.apply.outputs.stdout }}
+            ${{ steps.apply.outputs.body }}
             ${{ steps.apply.outputs.stderr }}
             \`\`\`
 

--- a/action.yml
+++ b/action.yml
@@ -85,15 +85,19 @@ runs:
       with:
         terraform_version: ${{ inputs.terraform-version }}
 
+    - name: Terraform Init
+      id: init
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: terraform init ${{ inputs.terraform-init-flags }}
+
     - name: Terraform Apply
       id: apply
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       env:
         TF_WORKSPACE: ${{ inputs.terraform-workspace }}
-      run: |
-        terraform init ${{ inputs.terraform-init-flags }}
-        terraform apply -input=false -no-color ${{ inputs.auto-approve == 'true' && '-auto-approve' || '' }} ${{ inputs.terraform-apply-flags }} |& tee apply.log
+      run: "terraform apply -input=false -no-color ${{ inputs.auto-approve == 'true' && '-auto-approve' || '' }} ${{ inputs.terraform-apply-flags }} |& tee apply.log"
       continue-on-error: true
 
     - name: Prepare Apply output for comment

--- a/action.yml
+++ b/action.yml
@@ -189,7 +189,7 @@ runs:
             <details open><summary>Show Output</summary>
 
             \`\`\`
-            ${{ steps.apply.outputs.body }}
+            ${{ steps.output.outputs.body }}
             ${{ steps.apply.outputs.stderr }}
             \`\`\`
 

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 name: Terraform Apply a Pull Request
 description: This workflow will run terraform apply on the merge commit of a pull request and upload the output to S3 for persistence.
-author: jrafferty@tamu.edu
+author: jrafferty@tamu.edu, andrewjdean64@tamu.edu
 
 inputs:
   debug:
@@ -116,7 +116,7 @@ runs:
 
         {
           echo "body<<EOF"
-          cat apply.log | grep -v 'Refreshing state...\|Reading...\|Read complete after'
+          cat apply.log | grep -v 'Refreshing state...\|Reading...\|Read complete after\|::debug::\|[command]/home/runner/work/'
           echo EOF
         } >> "$GITHUB_OUTPUT"
 

--- a/action.yml
+++ b/action.yml
@@ -111,8 +111,8 @@ runs:
         cat apply.log >> "$GITHUB_OUTPUT"
         echo "$EOF" >> "$GITHUB_OUTPUT"
 
-        echo -e "summary=$(cat apply.log | grep 'Apply complete' | jq -aRs .)" >> "$GITHUB_OUTPUT"
-        echo -e "body=$(cat apply.log | grep -v 'Refreshing state...\|Reading...\|Read complete after' | jq -aRs .)" >> "$GITHUB_OUTPUT"
+        echo -e "summary=$(cat apply.log | grep 'Apply complete')" >> "$GITHUB_OUTPUT"
+        echo -e "body=$(cat apply.log | grep -v 'Refreshing state...\|Reading...\|Read complete after')" >> "$GITHUB_OUTPUT"
 
     - name: Generate s3 key name
       id: s3

--- a/action.yml
+++ b/action.yml
@@ -111,8 +111,8 @@ runs:
         cat apply.log >> "$GITHUB_OUTPUT"
         echo "$EOF" >> "$GITHUB_OUTPUT"
 
-        echo "summary=$(cat apply.log | grep 'Apply complete')" >> "$GITHUB_OUTPUT"
-        echo "body=$(cat apply.log | grep -v 'Refreshing state...\|Reading...\|Read complete after')" >> "$GITHUB_OUTPUT"
+        echo "summary=$(cat apply.log | grep 'Apply complete' | jq -aRs .)" >> "$GITHUB_OUTPUT"
+        echo "body=$(cat apply.log | grep -v 'Refreshing state...\|Reading...\|Read complete after' | jq -aRs .)" >> "$GITHUB_OUTPUT"
 
     - name: Generate s3 key name
       id: s3

--- a/action.yml
+++ b/action.yml
@@ -117,7 +117,7 @@ runs:
     - name: Generate s3 key name
       id: s3
       shell: bash
-      woN3k0SH1n1g@m!z6rking-directory: ${{ inputs.working-directory }}
+      working-directory: ${{ inputs.working-directory }}
       run: |
         # Download hcl2json
         curl -Lo hcl2json $(curl -s https://api.github.com/repos/tmccombs/hcl2json/releases | jq -r '.[] | select(.tag_name == "v0.5.0").assets[] | select(.name == "hcl2json_linux_amd64").browser_download_url')

--- a/action.yml
+++ b/action.yml
@@ -112,7 +112,12 @@ runs:
         echo "$EOF" >> "$GITHUB_OUTPUT"
 
         echo "summary=$(cat apply.log | grep 'Apply complete')" >> "$GITHUB_OUTPUT"
-        echo "body=$(cat apply.log | grep -v 'Refreshing state...\|Reading...\|Read complete after' | jq -aRs .)" >> $GITHUB_OUTPUT
+
+        {
+          echo "body<<EOF"
+          cat apply.log | grep -v 'Refreshing state...\|Reading...\|Read complete after'
+          echo EOF
+        } >> "$GITHUB_OUTPUT"
 
     - name: Generate s3 key name
       id: s3

--- a/action.yml
+++ b/action.yml
@@ -112,7 +112,7 @@ runs:
         echo "$EOF" >> "$GITHUB_OUTPUT"
 
         echo "summary=$(cat apply.log | grep 'Apply complete')" >> "$GITHUB_OUTPUT"
-        echo "body=$(cat apply.log | grep -v 'Refreshing state...\|Reading...\|Read complete after')" >> $GITHUB_OUTPUT
+        echo "body=$(cat apply.log | grep -v 'Refreshing state...\|Reading...\|Read complete after' | jq -aRs .)" >> $GITHUB_OUTPUT
 
     - name: Generate s3 key name
       id: s3


### PR DESCRIPTION
The current `main` branch strategy of `echo "${{ steps.apply.outputs.stdout }}" >> apply.log` inadvertently escapes string sequences in the Terraform printout standard output (of which there are plenty). Any bash-unsafe characters are open to shell interpretation inside strings, causing the potential for syntax errors at best and shell injection at worst.

This introduces the `tee` command to simultaneously print the standard output/standard error and write to an apply.log file, rather than print the output >> append to file in future steps.

This PR also includes the change to the GitHub comment that removes the noisy "refreshing state/reading data source/read complete after" portions of the Terraform printout(still preserved in the apply.log), which helps with comment readability and, in some cases (for larger statefiles), comment size.